### PR TITLE
Unhandled promise rejections for the 1.5.10 release

### DIFF
--- a/docs/app/e2e/api-docs/service-pages.scenario.js
+++ b/docs/app/e2e/api-docs/service-pages.scenario.js
@@ -10,7 +10,7 @@ describe('service pages', function() {
 
     browser.get('build/docs/index.html#!/api/ng/service/$q');
     providerLink = element.all(by.css('ol.api-profile-header-structure li a')).first();
-    expect(providerLink.getText()).not.toEqual('- $qProvider');
+    expect(providerLink.getText()).not.toEqual('- $compileProvider');
     expect(providerLink.getAttribute('href')).not.toMatch(/api\/ng\/provider\/\$compileProvider/);
   });
 

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3123,7 +3123,7 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               childBoundTranscludeFn);
           }
           linkQueue = null;
-        });
+        }).catch(noop);
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {
         var childBoundTranscludeFn = boundTranscludeFn;

--- a/src/ng/compile.js
+++ b/src/ng/compile.js
@@ -3123,6 +3123,10 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
               childBoundTranscludeFn);
           }
           linkQueue = null;
+        }).catch(function(error) {
+          if (error instanceof Error) {
+            $exceptionHandler(error);
+          }
         }).catch(noop);
 
       return function delayedNodeLinkFn(ignoreChildLinkFn, scope, node, rootElement, boundTranscludeFn) {

--- a/src/ng/interval.js
+++ b/src/ng/interval.js
@@ -189,6 +189,8 @@ function $IntervalProvider() {
       */
     interval.cancel = function(promise) {
       if (promise && promise.$$intervalId in intervals) {
+        // Interval cancels should not report as unhandled promise.
+        intervals[promise.$$intervalId].promise.catch(noop);
         intervals[promise.$$intervalId].reject('canceled');
         $window.clearInterval(promise.$$intervalId);
         delete intervals[promise.$$intervalId];

--- a/src/ng/q.js
+++ b/src/ng/q.js
@@ -218,22 +218,59 @@
  *
  * @returns {Promise} The newly created promise.
  */
+/**
+ * @ngdoc provider
+ * @name $qProvider
+ *
+ * @description
+ */
 function $QProvider() {
-
+  var errorOnUnhandledRejections = true;
   this.$get = ['$rootScope', '$exceptionHandler', function($rootScope, $exceptionHandler) {
     return qFactory(function(callback) {
       $rootScope.$evalAsync(callback);
-    }, $exceptionHandler);
+    }, $exceptionHandler, errorOnUnhandledRejections);
   }];
+
+  /**
+   * @ngdoc method
+   * @name $qProvider#errorOnUnhandledRejections
+   * @kind function
+   *
+   * @description
+   * Retrieves or overrides whether to generate an error when a rejected promise is not handled.
+   *
+   * @param {boolean=} value Whether to generate an error when a rejected promise is not handled.
+   * @returns {boolean|ng.$qProvider} Current value when called without a new value or self for
+   *    chaining otherwise.
+   */
+  this.errorOnUnhandledRejections = function(value) {
+    if (isDefined(value)) {
+      errorOnUnhandledRejections = value;
+      return this;
+    } else {
+      return errorOnUnhandledRejections;
+    }
+  };
 }
 
 /** @this */
 function $$QProvider() {
+  var errorOnUnhandledRejections = true;
   this.$get = ['$browser', '$exceptionHandler', function($browser, $exceptionHandler) {
     return qFactory(function(callback) {
       $browser.defer(callback);
-    }, $exceptionHandler);
+    }, $exceptionHandler, errorOnUnhandledRejections);
   }];
+
+  this.errorOnUnhandledRejections = function(value) {
+    if (isDefined(value)) {
+      errorOnUnhandledRejections = value;
+      return this;
+    } else {
+      return errorOnUnhandledRejections;
+    }
+  };
 }
 
 /**
@@ -242,10 +279,14 @@ function $$QProvider() {
  * @param {function(function)} nextTick Function for executing functions in the next turn.
  * @param {function(...*)} exceptionHandler Function into which unexpected exceptions are passed for
  *     debugging purposes.
+ * @param {=boolean} errorOnUnhandledRejections Whether an error should be generated on unhandled
+ *     promises rejections.
  * @returns {object} Promise manager.
  */
-function qFactory(nextTick, exceptionHandler) {
+function qFactory(nextTick, exceptionHandler, errorOnUnhandledRejections) {
   var $qMinErr = minErr('$q', TypeError);
+  var queueSize = 0;
+  var checkQueue = [];
 
   /**
    * @ngdoc method
@@ -310,28 +351,62 @@ function qFactory(nextTick, exceptionHandler) {
     pending = state.pending;
     state.processScheduled = false;
     state.pending = undefined;
-    for (var i = 0, ii = pending.length; i < ii; ++i) {
-      deferred = pending[i][0];
-      fn = pending[i][state.status];
-      try {
-        if (isFunction(fn)) {
-          deferred.resolve(fn(state.value));
-        } else if (state.status === 1) {
-          deferred.resolve(state.value);
-        } else {
-          deferred.reject(state.value);
+    try {
+      for (var i = 0, ii = pending.length; i < ii; ++i) {
+        state.pur = true;
+        deferred = pending[i][0];
+        fn = pending[i][state.status];
+        try {
+          if (isFunction(fn)) {
+            deferred.resolve(fn(state.value));
+          } else if (state.status === 1) {
+            deferred.resolve(state.value);
+          } else {
+            deferred.reject(state.value);
+          }
+        } catch (e) {
+          deferred.reject(e);
+          exceptionHandler(e);
         }
-      } catch (e) {
-        deferred.reject(e);
-        exceptionHandler(e);
+      }
+    } finally {
+      --queueSize;
+      if (errorOnUnhandledRejections && queueSize === 0) {
+        nextTick(processChecksFn());
       }
     }
   }
 
+  function processChecks() {
+    while (!queueSize && checkQueue.length) {
+      var toCheck = checkQueue.shift();
+      if (!toCheck.pur) {
+        toCheck.pur = true;
+        var errorMessage = 'Possibly unhandled rejection: ' + toDebugString(toCheck.value);
+        exceptionHandler(errorMessage);
+      }
+    }
+  }
+
+  function processChecksFn() {
+    return function() { processChecks(); };
+  }
+
+  function processQueueFn(state) {
+    return function() { processQueue(state); };
+  }
+
   function scheduleProcessQueue(state) {
+    if (errorOnUnhandledRejections && !state.pending && state.status === 2 && !state.pur) {
+      if (queueSize === 0 && checkQueue.length === 0) {
+        nextTick(processChecksFn());
+      }
+      checkQueue.push(state);
+    }
     if (state.processScheduled || !state.pending) return;
     state.processScheduled = true;
-    nextTick(function() { processQueue(state); });
+    ++queueSize;
+    nextTick(processQueueFn(state));
   }
 
   function Deferred() {

--- a/src/ng/timeout.js
+++ b/src/ng/timeout.js
@@ -84,6 +84,8 @@ function $TimeoutProvider() {
       */
     timeout.cancel = function(promise) {
       if (promise && promise.$$timeoutId in deferreds) {
+        // Timeout cancels should not report an unhandled promise.
+        deferreds[promise.$$timeoutId].promise.catch(noop);
         deferreds[promise.$$timeoutId].reject('canceled');
         delete deferreds[promise.$$timeoutId];
         return $browser.defer.cancel(promise.$$timeoutId);

--- a/src/ngMock/angular-mocks.js
+++ b/src/ngMock/angular-mocks.js
@@ -456,7 +456,7 @@ angular.mock.$IntervalProvider = function() {
           promise = deferred.promise;
 
       count = (angular.isDefined(count)) ? count : 0;
-      promise.then(null, null, (!hasParams) ? fn : function() {
+      promise.then(null, function() {}, (!hasParams) ? fn : function() {
         fn.apply(null, args);
       });
 
@@ -516,6 +516,7 @@ angular.mock.$IntervalProvider = function() {
       });
 
       if (angular.isDefined(fnIndex)) {
+        repeatFns[fnIndex].deferred.promise.then(undefined, function() {});
         repeatFns[fnIndex].deferred.reject('canceled');
         repeatFns.splice(fnIndex, 1);
         return true;

--- a/src/ngResource/resource.js
+++ b/src/ngResource/resource.js
@@ -802,13 +802,14 @@ angular.module('ngResource', ['ng']).
               return $q.reject(response);
             });
 
-            promise['finally'](function() {
+            promise = promise['finally'](function(response) {
               value.$resolved = true;
               if (!isInstanceCall && cancellable) {
                 value.$cancelRequest = noop;
                 $timeout.cancel(numericTimeoutPromise);
                 timeoutDeferred = numericTimeoutPromise = httpConfig.timeout = null;
               }
+              return response;
             });
 
             promise = promise.then(

--- a/test/ng/animateRunnerSpec.js
+++ b/test/ng/animateRunnerSpec.js
@@ -204,7 +204,7 @@ describe('$$AnimateRunner', function() {
         var animationComplete = false;
         runner['finally'](function() {
           animationComplete = true;
-        });
+        }).then(noop, noop);;
         runner[method]();
         $rootScope.$digest();
         expect(animationComplete).toBe(true);

--- a/test/ng/httpSpec.js
+++ b/test/ng/httpSpec.js
@@ -1032,7 +1032,7 @@ describe('$http', function() {
 
       it('should $apply after error callback', function() {
         $httpBackend.when('GET').respond(404);
-        $http({method: 'GET', url: '/some'});
+        $http({method: 'GET', url: '/some'}).catch(noop);
         $httpBackend.flush();
         expect($rootScope.$apply).toHaveBeenCalledOnce();
       });
@@ -1463,7 +1463,7 @@ describe('$http', function() {
 
       function doFirstCacheRequest(method, respStatus, headers) {
         $httpBackend.expect(method || 'GET', '/url').respond(respStatus || 200, 'content', headers);
-        $http({method: method || 'GET', url: '/url', cache: cache});
+        $http({method: method || 'GET', url: '/url', cache: cache}).catch(noop);
         $httpBackend.flush();
       }
 
@@ -1671,7 +1671,7 @@ describe('$http', function() {
 
       it('should preserve config object when rejecting from pending cache', function() {
         $httpBackend.expect('GET', '/url').respond(404, 'content');
-        $http({method: 'GET', url: '/url', cache: cache, headers: {foo: 'bar'}});
+        $http({method: 'GET', url: '/url', cache: cache, headers: {foo: 'bar'}}).catch(noop);
 
         $http({method: 'GET', url: '/url', cache: cache, headers: {foo: 'baz'}})['catch'](callback);
         $httpBackend.flush();

--- a/test/ng/timeoutSpec.js
+++ b/test/ng/timeoutSpec.js
@@ -165,7 +165,7 @@ describe('$timeout', function() {
       expect($exceptionHandler.errors).toEqual([]);
 
       $timeout.flush();
-      expect($exceptionHandler.errors).toEqual(['Test Error']);
+      expect($exceptionHandler.errors).toEqual(["Test Error", 'Possibly unhandled rejection: Test Error']);
     }));
 
 
@@ -238,7 +238,7 @@ describe('$timeout', function() {
       $timeout(task2);
       promise3 = $timeout(task3, 333);
       promise4 = $timeout(333);
-      promise3.then(task4);
+      promise3.then(task4, noop);
 
       $timeout.cancel(promise1);
       $timeout.cancel(promise3);

--- a/test/ngAnimate/animateCssSpec.js
+++ b/test/ngAnimate/animateCssSpec.js
@@ -1336,6 +1336,7 @@ describe('ngAnimate $animateCss', function() {
           animator.end();
 
           expect(element.data(ANIMATE_TIMER_KEY)).toBeUndefined();
+          $timeout.flush();
           expect(function() {$timeout.verifyNoPendingTasks();}).not.toThrow();
         }));
 

--- a/test/ngResource/resourceSpec.js
+++ b/test/ngResource/resourceSpec.js
@@ -1193,7 +1193,8 @@ describe('basic usage', function() {
     it('should call the error callback if provided on non 2xx response', function() {
       $httpBackend.expect('GET', '/CreditCard/123').respond(ERROR_CODE, ERROR_RESPONSE);
 
-      CreditCard.get({id:123}, callback, errorCB);
+      var ccs = CreditCard.get({id:123}, callback, errorCB);
+      ccs.$promise.then(noop, noop);
       $httpBackend.flush();
       expect(errorCB).toHaveBeenCalledOnce();
       expect(callback).not.toHaveBeenCalled();
@@ -1203,7 +1204,8 @@ describe('basic usage', function() {
     it('should call the error callback if provided on non 2xx response (without data)', function() {
       $httpBackend.expect('GET', '/CreditCard').respond(ERROR_CODE, ERROR_RESPONSE);
 
-      CreditCard.get(callback, errorCB);
+      var ccs = CreditCard.get(callback, errorCB);
+      ccs.$promise.then(noop, noop);
       $httpBackend.flush();
       expect(errorCB).toHaveBeenCalledOnce();
       expect(callback).not.toHaveBeenCalled();
@@ -1565,7 +1567,8 @@ describe('cancelling requests', function() {
       }
     });
 
-    CreditCard.get();
+    var ccs = CreditCard.get();
+    ccs.$promise.catch(noop);
     $httpBackend.flush();
 
     expect(httpSpy).toHaveBeenCalledOnce();
@@ -1728,7 +1731,9 @@ describe('cancelling requests', function() {
       }
     });
 
-    CreditCard.get().$cancelRequest();
+    var ccs = CreditCard.get();
+    ccs.$promise.catch(noop);
+    ccs.$cancelRequest();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
 
     CreditCard.get();
@@ -1746,7 +1751,9 @@ describe('cancelling requests', function() {
       }
     });
 
-    CreditCard.get().$cancelRequest();
+    var ccs = CreditCard.get();
+    ccs.$promise.catch(noop);
+    ccs.$cancelRequest();
     expect($httpBackend.flush).toThrow(new Error('No pending request to flush !'));
 
     CreditCard.get();


### PR DESCRIPTION
This PR contains changes on top of the 1.5.10 release that enable catching unhandled promise rejections in the $exceptionHandler decorator. Issue: https://github.com/angular/angular.js/issues/13653
The lowest version of official releases with the changes is 1.6.0. Migration from 1.5.10 (which simple engagements is using) to 1.6.0 will require a lot of code changes, so this is an alternative approach where we take the changes and apply them directly to 1.5.10 in order to get the new feature without migration.

The PR and commit below refer to the same code that was originally developed by the google team to address this problem (commit is a squash commit from 1.6.0 while the PR is an original PR for the issue that was closed and removed)

https://github.com/angular/angular.js/pull/13662/files
https://github.com/angular/angular.js/commit/c9dffde1cb167660120753181cb6d01dc1d1b3d0